### PR TITLE
feat(auth): thêm API đăng ký tài khoản (POST /api/auth/register)

### DIFF
--- a/controllers/auth_controller.go
+++ b/controllers/auth_controller.go
@@ -1,1 +1,59 @@
 package controllers
+
+import (
+    "net/http"
+
+    "github.com/gin-gonic/gin"
+    "github.com/vnkhanh/survey-server/config"
+    "github.com/vnkhanh/survey-server/models"
+    "github.com/vnkhanh/survey-server/utils"
+)
+
+type DangKyReq struct {
+    Ten     string `json:"ten" binding:"required,min=1"`
+    Email   string `json:"email" binding:"required,email"`
+    MatKhau string `json:"mat_khau" binding:"required,min=6"`
+}
+
+func Register(c *gin.Context) {
+    var req DangKyReq
+    if err := c.ShouldBindJSON(&req); err != nil {
+        c.JSON(http.StatusUnprocessableEntity, gin.H{"message": err.Error()})
+        return
+    }
+
+    var count int64
+    config.DB.Model(&models.NguoiDung{}).Where("email = ?", req.Email).Count(&count)
+    if count > 0 {
+        c.JSON(http.StatusConflict, gin.H{"message": "Email đã tồn tại"})
+        return
+    }
+
+    hash, err := utils.HashPassword(req.MatKhau)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể mã hóa mật khẩu"})
+        return
+    }
+
+    nd := models.NguoiDung{
+        Ten:     req.Ten,
+        Email:   req.Email,
+        MatKhau: hash,
+        VaiTro:  false,
+    }
+
+    if err := config.DB.Create(&nd).Error; err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể tạo tài khoản"})
+        return
+    }
+
+    c.JSON(http.StatusCreated, gin.H{
+        "user": gin.H{
+            "id":       nd.ID,
+            "ten":      nd.Ten,
+            "email":    nd.Email,
+            "vai_tro":  nd.VaiTro,
+            "ngay_tao": nd.NgayTao,
+        },
+    })
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -13,9 +13,11 @@ func SetupRoutes(r *gin.Engine) {
 	})
 	r.GET("/health", controllers.HealthCheck)
 
-	r.Group("/api")
+	api := r.Group("/api")
 	{
-		// Thêm các route khác ở đây
-
+		auth := api.Group("/auth")
+		{
+			auth.POST("/register", controllers.Register)
+		}
 	}
 }

--- a/utils/password.go
+++ b/utils/password.go
@@ -1,0 +1,11 @@
+package utils
+
+import "golang.org/x/crypto/bcrypt"
+
+func HashPassword(raw string) (string, error) {
+    b, err := bcrypt.GenerateFromPassword([]byte(raw), bcrypt.DefaultCost)
+    return string(b), err
+}
+func CheckPassword(hash, raw string) bool {
+    return bcrypt.CompareHashAndPassword([]byte(hash), []byte(raw)) == nil
+}


### PR DESCRIPTION
### Mô tả
- Thêm endpoint `POST /api/auth/register` cho phép người dùng đăng ký tài khoản mới.

### Thay đổi
- Validate email duy nhất (unique).
- Hash mật khẩu bằng bcrypt trước khi lưu DB.
- Tạo user mới với role mặc định `vai_tro = false`.
- Trả về thông tin user sau khi đăng ký:
  - id
  - ten
  - email
  - vai_tro
  - ngay_tao

### Response mẫu (201 Created)
{
  "user": {
    "id": 1,
    "ten": "Nguyen Van A",
    "email": "a@example.com",
    "vai_tro": false,
    "ngay_tao": "2025-09-03T19:07:14.985447+07:00"
  }
}

### Trường hợp lỗi
- 409 Conflict: Email đã tồn tại
- 422 Unprocessable Entity: Dữ liệu gửi lên không hợp lệ