### PR TITLE
feat(auth): JWT middleware + /api/me + RequireAdmin

### DIFF
--- a/controllers/auth_controller.go
+++ b/controllers/auth_controller.go
@@ -57,3 +57,7 @@ func Register(c *gin.Context) {
         },
     })
 }
+
+func Me(c *gin.Context) {
+	c.JSON(http.StatusOK, c.MustGet("userPublic"))
+}

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,0 +1,73 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/vnkhanh/survey-server/config"
+	"github.com/vnkhanh/survey-server/models"
+	"github.com/vnkhanh/survey-server/utils"
+)
+
+// AuthJWT kiểm tra Authorization: Bearer <token>, validate JWT, lấy user và inject vào context.
+func AuthJWT() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" || !strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "Missing or invalid Authorization header"})
+			return
+		}
+		rawToken := strings.TrimSpace(authHeader[7:])
+
+		claims, err := utils.VerifyToken(rawToken)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "Invalid token"})
+			return
+		}
+
+		// UserID trong claims là string → parse ra uint64 để tìm DB theo primary key
+		uid, err := strconv.ParseUint(claims.UserID, 10, 64)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "Invalid subject"})
+			return
+		}
+
+		var user models.NguoiDung
+		if err := config.DB.First(&user, uid).Error; err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "User not found"})
+			return
+		}
+
+		// Inject vào context
+		c.Set("user", user)
+		c.Set("userPublic", gin.H{
+			"id":       user.ID,
+			"ten":      user.Ten,
+			"email":    user.Email,
+			"vai_tro":  user.VaiTro,
+			"ngay_tao": user.NgayTao,
+		})
+
+		c.Next()
+	}
+}
+
+// RequireAdmin chặn các route chỉ dành cho admin
+func RequireAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		v, ok := c.Get("user")
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "Unauthorized"})
+			return
+		}
+		u := v.(models.NguoiDung)
+		if !u.VaiTro {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"message": "Forbidden"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -19,5 +19,18 @@ func SetupRoutes(r *gin.Engine) {
 		{
 			auth.POST("/register", controllers.Register)
 		}
+		protected := api.Group("/")
+		protected.Use(middleware.AuthJWT())
+		{
+			protected.GET("/me", controllers.Me)
+		}
+
+		admin := protected.Group("/admin")
+		admin.Use(middleware.RequireAdmin())
+		{
+			admin.GET("/only", func(c *gin.Context) {
+				c.JSON(200, gin.H{"ok": true})
+			})
+		}
 	}
 }


### PR DESCRIPTION
## Mục tiêu
Thêm cơ chế xác thực JWT cho API, bảo vệ route yêu cầu đăng nhập và phân quyền cho admin.

## Nội dung thay đổi
- Thêm middleware `AuthJWT`:
  - Đọc header Authorization (Bearer <token>).
  - Xác minh JWT bằng `utils.VerifyToken`.
  - Parse claims để lấy userID, tìm `NguoiDung` trong DB.
  - Gắn thông tin user vào Gin context:
    - `user`: đối tượng đầy đủ từ DB.
    - `userPublic`: bản rút gọn (id, ten, email, vai_tro, ngay_tao).

- Thêm middleware `RequireAdmin`:
  - Chỉ cho phép truy cập route nếu `user.VaiTro = true`.
  - Trả 403 nếu user thường.

- Route mới:
  - `GET /api/me` → trả `userPublic` từ JWT (protected).
  - `GET /api/admin/only` → chỉ admin truy cập được.

## Cấu hình
- Dùng biến môi trường `JWT_SECRET` từ `.env`.
- Token TTL = 24h (hardcode trong utils).

## Test thủ công
1. Đăng ký user mới → Login lấy token.
2. Gọi `GET /api/me` kèm header `Authorization: Bearer <token>` → 200 OK, trả thông tin userPublic.
3. Gọi `GET /api/admin/only` với user thường → 403 Forbidden.
4. Update `vai_tro=true` trong DB → Login lại → gọi `/api/admin/only` → 200 OK.

## Ghi chú
- Đây là nền tảng để bảo vệ các API sau này.
- Sử dụng trực tiếp string key (`"user"`, `"userPublic"`) trong Gin context (chưa tách ra const).
