### PR TITLE
feat(auth): login API (POST /api/auth/login)

### DIFF
--- a/controllers/auth_controller.go
+++ b/controllers/auth_controller.go
@@ -57,3 +57,7 @@ func Register(c *gin.Context) {
         },
     })
 }
+
+func Me(c *gin.Context) {
+	c.JSON(http.StatusOK, c.MustGet("userPublic"))
+}

--- a/controllers/auth_controller.go
+++ b/controllers/auth_controller.go
@@ -2,9 +2,13 @@ package controllers
 
 import (
     "net/http"
+	"strconv"
+	"strings"
+	"time"
 
     "github.com/gin-gonic/gin"
     "github.com/vnkhanh/survey-server/config"
+	"github.com/vnkhanh/survey-server/middleware"
     "github.com/vnkhanh/survey-server/models"
     "github.com/vnkhanh/survey-server/utils"
 )
@@ -22,8 +26,10 @@ func Register(c *gin.Context) {
         return
     }
 
+	email := strings.TrimSpace(strings.ToLower(req.Email))
+
     var count int64
-    config.DB.Model(&models.NguoiDung{}).Where("email = ?", req.Email).Count(&count)
+    config.DB.Model(&models.NguoiDung{}).Where("email = ?", email).Count(&count)
     if count > 0 {
         c.JSON(http.StatusConflict, gin.H{"message": "Email đã tồn tại"})
         return
@@ -37,7 +43,7 @@ func Register(c *gin.Context) {
 
     nd := models.NguoiDung{
         Ten:     req.Ten,
-        Email:   req.Email,
+        Email:   email,
         MatKhau: hash,
         VaiTro:  false,
     }
@@ -59,5 +65,64 @@ func Register(c *gin.Context) {
 }
 
 func Me(c *gin.Context) {
-	c.JSON(http.StatusOK, c.MustGet("userPublic"))
+	c.JSON(http.StatusOK, c.MustGet(middleware.CtxUserPublic))
+}
+
+type loginRequest struct {
+	Email   string `json:"email" binding:"required,email"`
+	MatKhau string `json:"mat_khau" binding:"required,min=6"`
+}
+
+func Login(c *gin.Context) {
+	var req loginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"message": "Dữ liệu không hợp lệ",
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	email := strings.TrimSpace(strings.ToLower(req.Email))
+
+	// Tìm user theo email
+	var u models.NguoiDung
+	if err := config.DB.Where("email = ?", email).First(&u).Error; err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"message": "Email hoặc mật khẩu không đúng"})
+		return
+	}
+
+	// So khớp mật khẩu (chú ý thứ tự: hash trước, raw sau)
+	if ok := utils.CheckPassword(u.MatKhau, req.MatKhau); !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"message": "Email hoặc mật khẩu không đúng"})
+		return
+	}
+
+	// Vai trò trong token
+	role := "user"
+	if u.VaiTro {
+		role = "admin"
+	}
+
+	// Tạo JWT token
+	token, err := utils.GenerateToken(strconv.FormatUint(uint64(u.ID), 10), role)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không tạo được token"})
+		return
+	}
+
+	exp := time.Now().Add(24 * time.Hour)
+	
+	c.JSON(http.StatusOK, gin.H{
+		"token": token,
+		"expires_at": exp,
+        "role": role,
+		"user": gin.H{
+			"id":       u.ID,
+			"ten":      u.Ten,
+			"email":    u.Email,
+			"vai_tro":  u.VaiTro,
+			"ngay_tao": u.NgayTao,
+		},
+	})
 }

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -42,8 +42,8 @@ func AuthJWT() gin.HandlerFunc {
 		}
 
 		// Inject vào context
-		c.Set("user", user)
-		c.Set("userPublic", gin.H{
+		c.Set(CtxUser, user)
+        c.Set(CtxUserPublic, gin.H{
 			"id":       user.ID,
 			"ten":      user.Ten,
 			"email":    user.Email,

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,0 +1,73 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/vnkhanh/survey-server/config"
+	"github.com/vnkhanh/survey-server/models"
+	"github.com/vnkhanh/survey-server/utils"
+)
+
+// AuthJWT kiểm tra Authorization: Bearer <token>, validate JWT, lấy user và inject vào context.
+func AuthJWT() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" || !strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "Missing or invalid Authorization header"})
+			return
+		}
+		rawToken := strings.TrimSpace(authHeader[7:])
+
+		claims, err := utils.VerifyToken(rawToken)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "Invalid token"})
+			return
+		}
+
+		// UserID trong claims là string → parse ra uint64 để tìm DB theo primary key
+		uid, err := strconv.ParseUint(claims.UserID, 10, 64)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "Invalid subject"})
+			return
+		}
+
+		var user models.NguoiDung
+		if err := config.DB.First(&user, uid).Error; err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "User not found"})
+			return
+		}
+
+		// Inject vào context
+		c.Set("user", user)
+		c.Set("userPublic", gin.H{
+			"id":       user.ID,
+			"ten":      user.Ten,
+			"email":    user.Email,
+			"vai_tro":  user.VaiTro,
+			"ngay_tao": user.NgayTao,
+		})
+
+		c.Next()
+	}
+}
+
+// RequireAdmin chặn các route chỉ dành cho admin
+func RequireAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		v, ok := c.Get("user")
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "Unauthorized"})
+			return
+		}
+		u := v.(models.NguoiDung)
+		if !u.VaiTro {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"message": "Forbidden"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/middleware/ctxkeys.go
+++ b/middleware/ctxkeys.go
@@ -1,0 +1,6 @@
+package middleware
+
+const (
+    CtxUser       = "user"
+    CtxUserPublic = "userPublic"
+)

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -19,5 +19,18 @@ func SetupRoutes(r *gin.Engine) {
 		{
 			auth.POST("/register", controllers.Register)
 		}
+		protected := api.Group("/")
+		protected.Use(middleware.AuthJWT())
+		{
+			protected.GET("/me", controllers.Me)
+		}
+
+		admin := protected.Group("/admin")
+		admin.Use(middleware.RequireAdmin())
+		{
+			admin.GET("/only", func(c *gin.Context) {
+				c.JSON(200, gin.H{"ok": true})
+			})
+		}
 	}
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/vnkhanh/survey-server/controllers"
+	"github.com/vnkhanh/survey-server/middleware"
 )
 
 func SetupRoutes(r *gin.Engine) {
@@ -18,6 +19,7 @@ func SetupRoutes(r *gin.Engine) {
 		auth := api.Group("/auth")
 		{
 			auth.POST("/register", controllers.Register)
+			auth.POST("/login", controllers.Login)
 		}
 		protected := api.Group("/")
 		protected.Use(middleware.AuthJWT())


### PR DESCRIPTION
## Mục tiêu
Thêm API login để người dùng đăng nhập bằng email/mật khẩu, nhận JWT token phục vụ cho các request protected.

## Nội dung thay đổi
- API mới: `POST /api/auth/login`
  - Nhận `email`, `mat_khau` từ body JSON.
  - Chuẩn hoá email (lowercase + trim) trước khi query DB.
  - Tìm user trong DB, so khớp mật khẩu bằng bcrypt.
  - Nếu đúng → phát JWT chứa userID + role.
  - Trả JSON:
    {
      "token": "<JWT>",
      "expires_at": "<ISO8601 time>",
      "role": "user/admin",
      "user": { ... }
    }

- Cập nhật `controllers/auth_controller.go`:
  - Bổ sung hàm `Login`.
  - Trả thêm `expires_at` (24h TTL) và `role`.

- Cập nhật `routes/routes.go`:
  - Thêm route `POST /api/auth/login`.

- (Refactor) Tạo file `middleware/ctxkeys.go`:
  - Định nghĩa `CtxUser`, `CtxUserPublic` để thay cho string literal trong context.
  - Sửa `AuthJWT`, `Me` để dùng const key thay vì string.

## Cấu hình
- JWT TTL = 24h (hardcode, có thể đổi sang ENV trong tương lai).
- Dùng chung `JWT_SECRET` từ `.env`.

## Test thủ công
1. Đăng ký user → Login.
2. Kết quả login: 200 OK, trả token + expires_at + role + user.
3. Dùng token gọi `/api/me` → 200 OK, trả thông tin userPublic.
4. Với user admin (`vai_tro=true`) → gọi `/api/admin/only` → 200 OK.

## Ghi chú
- Bổ sung const key để chuẩn hoá context (so với PR 2).
- Hoàn thiện pipeline Auth (Register → JWT Middleware → Login).
