### PR TITLE
feat(forms): BE-01..BE-10 (forms, questions, settings)

### DIFF
--- a/controllers/form_controller.go
+++ b/controllers/form_controller.go
@@ -1,0 +1,298 @@
+package controllers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/vnkhanh/survey-server/config"
+	"github.com/vnkhanh/survey-server/middleware"
+	"github.com/vnkhanh/survey-server/models"
+)
+
+/* ========== BE-01: Tạo biểu mẫu khảo sát ========== */
+
+type createFormReq struct {
+	Title       string          `json:"title"       binding:"required,min=1"`
+	Description string          `json:"description"`
+	TemplateID  *uint           `json:"template_id"` // để mở rộng
+	Settings    json.RawMessage `json:"settings"`    // JSON tuỳ chọn (lưu TEXT)
+	Theme       json.RawMessage `json:"theme"`       // JSON tuỳ chọn (lưu TEXT)
+}
+
+func CreateForm(c *gin.Context) {
+	u := c.MustGet(middleware.CtxUser).(models.NguoiDung)
+
+	var req createFormReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "Payload không hợp lệ", "error": err.Error()})
+		return
+	}
+
+	// Validate JSON fields (nếu truyền lên)
+	if len(req.Settings) > 0 && !json.Valid(req.Settings) {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "settings không phải JSON hợp lệ"})
+		return
+	}
+	if len(req.Theme) > 0 && !json.Valid(req.Theme) {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "theme không phải JSON hợp lệ"})
+		return
+	}
+
+	form := models.KhaoSat{
+		TieuDe:     req.Title,
+		MoTa:       req.Description,
+		NguoiTaoID: u.ID,
+		TrangThai:  "active", // dùng ngay
+		TemplateID: req.TemplateID,
+	}
+	if len(req.Settings) > 0 {
+		form.SettingsJSON = string(req.Settings)
+	}
+	if len(req.Theme) > 0 {
+		form.ThemeJSON = string(req.Theme)
+	}
+
+	if err := config.DB.Create(&form).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể tạo form"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"id":          form.ID,
+		"title":       form.TieuDe,
+		"description": form.MoTa,
+		"owner_id":    form.NguoiTaoID,
+		"created_at":  form.NgayTao,
+	})
+}
+
+/* ========== BE-02: Xem chi tiết form ========== */
+
+func GetFormDetail(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "ID không hợp lệ"})
+		return
+	}
+
+	var form models.KhaoSat
+	err = config.DB.
+		Where("id = ? AND trang_thai <> 'deleted'", id).
+		Preload("CauHois", func(db *gorm.DB) *gorm.DB { return db.Order("thu_tu ASC, id ASC") }).
+		Preload("CauHois.LuaChons", func(db *gorm.DB) *gorm.DB { return db.Order("thu_tu ASC, id ASC") }).
+		First(&form).Error
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{"message": "Form không tồn tại"})
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể lấy form"})
+		return
+	}
+
+	var settings, theme interface{}
+	if form.SettingsJSON != "" {
+		_ = json.Unmarshal([]byte(form.SettingsJSON), &settings)
+	}
+	if form.ThemeJSON != "" {
+		_ = json.Unmarshal([]byte(form.ThemeJSON), &theme)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"id":          form.ID,
+		"title":       form.TieuDe,
+		"description": form.MoTa,
+		"settings":    settings,
+		"theme":       theme,
+		"questions":   form.CauHois,
+	})
+}
+
+/* ========== BE-03: Cập nhật form (owner-only) ========== */
+
+type updateFormReq struct {
+	Title       *string          `json:"title"`
+	Description *string          `json:"description"`
+	Settings    *json.RawMessage `json:"settings"`
+}
+
+func UpdateForm(c *gin.Context) {
+	f := c.MustGet("formObj").(models.KhaoSat)
+
+	var req updateFormReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "Payload không hợp lệ", "error": err.Error()})
+		return
+	}
+
+	if req.Settings != nil && len(*req.Settings) > 0 && !json.Valid(*req.Settings) {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "settings không phải JSON hợp lệ"})
+		return
+	}
+
+	updates := map[string]interface{}{}
+	if req.Title != nil {
+		updates["tieu_de"] = *req.Title
+	}
+	if req.Description != nil {
+		updates["mo_ta"] = *req.Description
+	}
+	if req.Settings != nil {
+		updates["settings_json"] = string(*req.Settings)
+	}
+	if len(updates) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Không có gì để cập nhật"})
+		return
+	}
+
+	if err := config.DB.Model(&models.KhaoSat{}).
+		Where("id = ?", f.ID).
+		Updates(updates).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Cập nhật thất bại"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "updated"})
+}
+
+/* ========== BE-04: Xoá form (owner-only) — xóa mềm ========== */
+
+func DeleteForm(c *gin.Context) {
+	f := c.MustGet("formObj").(models.KhaoSat)
+	if err := config.DB.Model(&models.KhaoSat{}).
+		Where("id = ?", f.ID).
+		Update("trang_thai", "deleted").Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Xoá (mềm) thất bại"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "deleted"})
+}
+
+/* ========== BE-04 (tuỳ chọn): Archive/Restore bằng trang_thai ========== */
+
+func ArchiveForm(c *gin.Context) {
+	f := c.MustGet("formObj").(models.KhaoSat)
+	if err := config.DB.Model(&models.KhaoSat{}).
+		Where("id = ?", f.ID).
+		Update("trang_thai", "archived").Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Archive thất bại"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "archived"})
+}
+
+func RestoreForm(c *gin.Context) {
+	f := c.MustGet("formObj").(models.KhaoSat)
+	if err := config.DB.Model(&models.KhaoSat{}).
+		Where("id = ?", f.ID).
+		Update("trang_thai", "active").Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Restore thất bại"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "restored"})
+}
+
+/* ========== BE-08: Sắp xếp lại câu hỏi (owner-only) ========== */
+
+type reorderReq struct {
+	Order []uint `json:"order" binding:"required,min=1,dive,required"`
+}
+
+func ReorderQuestions(c *gin.Context) {
+	f := c.MustGet("formObj").(models.KhaoSat)
+
+	var req reorderReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "Payload không hợp lệ", "error": err.Error()})
+		return
+	}
+
+	// Validate: tất cả qID đều thuộc form
+	var count int64
+	if err := config.DB.Model(&models.CauHoi{}).
+		Where("khao_sat_id = ? AND id IN ?", f.ID, req.Order).
+		Count(&count).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể validate câu hỏi"})
+		return
+	}
+	if count != int64(len(req.Order)) {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Danh sách order chứa câu hỏi không thuộc form"})
+		return
+	}
+
+	err := config.DB.Transaction(func(tx *gorm.DB) error {
+		for idx, qID := range req.Order {
+			if err := tx.Model(&models.CauHoi{}).
+				Where("id = ? AND khao_sat_id = ?", qID, f.ID).
+				Update("thu_tu", idx).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Cập nhật thứ tự thất bại"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "updated"})
+}
+
+/* ========== BE-09: Cập nhật cài đặt form (owner-only) ========== */
+
+type updateSettingsReq struct {
+	Settings json.RawMessage `json:"settings" binding:"required"`
+}
+
+func UpdateFormSettings(c *gin.Context) {
+	f := c.MustGet("formObj").(models.KhaoSat)
+
+	var req updateSettingsReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "Payload không hợp lệ", "error": err.Error()})
+		return
+	}
+	if len(req.Settings) == 0 || !json.Valid(req.Settings) {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "settings không phải JSON hợp lệ"})
+		return
+	}
+	if err := config.DB.Model(&models.KhaoSat{}).
+		Where("id = ?", f.ID).
+		Update("settings_json", string(req.Settings)).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Lưu settings thất bại"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "updated"})
+}
+
+/* ========== BE-10: Lấy cài đặt form ========== */
+
+func GetFormSettings(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "ID không hợp lệ"})
+		return
+	}
+
+	var f models.KhaoSat
+	if e := config.DB.Select("id, settings_json").
+		Where("id = ? AND trang_thai <> 'deleted'", id).
+		First(&f).Error; e != nil {
+		if errors.Is(e, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"message": "Form không tồn tại"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể lấy settings"})
+		return
+	}
+
+	var settings interface{}
+	if f.SettingsJSON != "" {
+		_ = json.Unmarshal([]byte(f.SettingsJSON), &settings)
+	}
+	c.JSON(http.StatusOK, gin.H{"settings": settings})
+}

--- a/controllers/question_controller.go
+++ b/controllers/question_controller.go
@@ -1,0 +1,198 @@
+package controllers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/vnkhanh/survey-server/config"
+	"github.com/vnkhanh/survey-server/middleware"
+	"github.com/vnkhanh/survey-server/models"
+)
+
+/* ========== BE-05: Thêm câu hỏi (owner-only) ========== */
+
+type addQuestionReq struct {
+	Type    string `json:"type"    binding:"required"`
+	Content string `json:"content" binding:"required"`
+	Props   json.RawMessage `json:"props"`
+}
+
+func AddQuestion(c *gin.Context) {
+	f := c.MustGet("formObj").(models.KhaoSat)
+
+	var req addQuestionReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "Payload không hợp lệ", "error": err.Error()})
+		return
+	}
+
+	// Chuẩn hoá type
+	req.Type = strings.ToUpper(strings.TrimSpace(req.Type))
+
+	// Lấy index kế tiếp = MAX(thu_tu)+1 (0-based)
+	type nextRes struct{ Next int }
+	var r nextRes
+	_ = config.DB.Model(&models.CauHoi{}).
+		Where("khao_sat_id = ?", f.ID).
+		Select("COALESCE(MAX(thu_tu), -1) + 1 AS next").
+		Scan(&r).Error
+
+	if len(req.Props) > 0 && !json.Valid(req.Props) {
+    c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "props không phải JSON hợp lệ"})
+    return
+	}	
+
+	q := models.CauHoi{
+		KhaoSatID:  f.ID,
+		NoiDung:    req.Content,
+		LoaiCauHoi: req.Type,
+		ThuTu:      r.Next,
+	}
+
+	if len(req.Props) > 0 {
+    q.PropsJSON = string(req.Props) // <-- LƯU
+	}
+
+	if err := config.DB.Create(&q).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể thêm câu hỏi"})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"question_id": q.ID, "form_id": f.ID})
+}
+
+/* ========== BE-06: Cập nhật câu hỏi (owner-only) ========== */
+
+type updateQuestionReq struct {
+	Content *string `json:"content"`
+	Props   *json.RawMessage `json:"props"`
+}
+
+func UpdateQuestion(c *gin.Context) {
+	qid, err := strconv.Atoi(c.Param("id"))
+	if err != nil || qid <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "ID không hợp lệ"})
+		return
+	}
+
+	var q models.CauHoi
+	if err := config.DB.First(&q, qid).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"message": "Câu hỏi không tồn tại"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể lấy câu hỏi"})
+		return
+	}
+
+	// Xác thực owner thông qua form (và loại trừ form deleted)
+	u := c.MustGet(middleware.CtxUser).(models.NguoiDung)
+	var f models.KhaoSat
+	if err := config.DB.
+		Select("id, nguoi_tao_id, trang_thai").
+		Where("id = ? AND trang_thai <> 'deleted'", q.KhaoSatID).
+		First(&f).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"message": "Form không tồn tại hoặc đã bị xoá"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể kiểm tra quyền"})
+		return
+	}
+	if f.NguoiTaoID != u.ID {
+		c.JSON(http.StatusForbidden, gin.H{"message": "Bạn không có quyền sửa câu hỏi này"})
+		return
+	}
+
+	var req updateQuestionReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "Payload không hợp lệ", "error": err.Error()})
+		return
+	}
+
+	if req.Props != nil && len(*req.Props) > 0 && !json.Valid(*req.Props) {
+    c.JSON(http.StatusUnprocessableEntity, gin.H{"message": "props không phải JSON hợp lệ"})
+    return
+	}
+
+	updates := map[string]interface{}{}
+	if req.Content != nil {
+		updates["noi_dung"] = *req.Content
+	}
+	if req.Props != nil {
+		updates["props_json"] = string(*req.Props)
+	}
+	if len(updates) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Không có gì để cập nhật"})
+		return
+	}
+
+	if err := config.DB.Model(&q).Updates(updates).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Cập nhật thất bại"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "updated"})
+}
+
+/* ========== BE-07: Xoá câu hỏi (owner-only) + dồn thứ tự ========== */
+
+func DeleteQuestion(c *gin.Context) {
+	qid, err := strconv.Atoi(c.Param("id"))
+	if err != nil || qid <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "ID không hợp lệ"})
+		return
+	}
+
+	var q models.CauHoi
+	if err := config.DB.First(&q, qid).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"message": "Câu hỏi không tồn tại"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể lấy câu hỏi"})
+		return
+	}
+
+	// Xác thực owner và loại trừ form deleted
+	u := c.MustGet(middleware.CtxUser).(models.NguoiDung)
+	var f models.KhaoSat
+	if err := config.DB.
+		Select("id, nguoi_tao_id, trang_thai").
+		Where("id = ? AND trang_thai <> 'deleted'", q.KhaoSatID).
+		First(&f).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"message": "Form không tồn tại hoặc đã bị xoá"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Không thể kiểm tra quyền"})
+		return
+	}
+	if f.NguoiTaoID != u.ID {
+		c.JSON(http.StatusForbidden, gin.H{"message": "Bạn không có quyền xoá câu hỏi này"})
+		return
+	}
+
+	err = config.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Delete(&q).Error; err != nil {
+			return err
+		}
+		// Dồn thứ tự: các câu phía sau lùi 1 (0-based)
+		if err := tx.Model(&models.CauHoi{}).
+			Where("khao_sat_id = ? AND thu_tu > ?", q.KhaoSatID, q.ThuTu).
+			Update("thu_tu", gorm.Expr("thu_tu - 1")).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Xoá thất bại"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "deleted"})
+}

--- a/middleware/owner.go
+++ b/middleware/owner.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/vnkhanh/survey-server/config"
+	"github.com/vnkhanh/survey-server/models"
+)
+
+// CheckFormOwner: nạp form vào context & xác thực sở hữu (loại trừ form đã deleted)
+func CheckFormOwner() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// user hiện tại (đã được AuthJWT set vào context với key CtxUser = "user")
+		u := c.MustGet(CtxUser).(models.NguoiDung)
+
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil || id <= 0 {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"message": "ID không hợp lệ"})
+			return
+		}
+
+		var f models.KhaoSat
+		// Không cho thao tác trên form đã "deleted"
+		if err := config.DB.
+			Where("id = ? AND trang_thai <> 'deleted'", id).
+			First(&f).Error; err != nil {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"message": "Form không tồn tại"})
+			return
+		}
+
+		// Chỉ owner được thao tác
+		if f.NguoiTaoID != u.ID {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"message": "Bạn không có quyền thao tác form này"})
+			return
+		}
+
+		// Đưa form vào context để controller dùng tiếp
+		c.Set("formObj", f)
+		c.Next()
+	}
+}

--- a/models/cau_hoi.go
+++ b/models/cau_hoi.go
@@ -7,6 +7,8 @@ type CauHoi struct {
 	LoaiCauHoi string `gorm:"column:loai_cau_hoi;size:50;not null" json:"loai_cau_hoi"`
 	ThuTu      int    `gorm:"column:thu_tu;default:0" json:"thu_tu"`
 
+	PropsJSON string `gorm:"column:props_json;type:text" json:"-"`
+
 	// Quan hệ
 	LuaChons   []LuaChon   `gorm:"foreignKey:CauHoiID" json:"-"`
 	CauTraLois []CauTraLoi `gorm:"foreignKey:CauHoiID" json:"-"`

--- a/models/khao_sat.go
+++ b/models/khao_sat.go
@@ -10,7 +10,11 @@ type KhaoSat struct {
 	NguoiTaoID  uint       `gorm:"column:nguoi_tao_id" json:"nguoi_tao_id"`
 	NgayTao     time.Time  `gorm:"column:ngay_tao;autoCreateTime" json:"ngay_tao"`
 	NgayKetThuc *time.Time `gorm:"column:ngay_ket_thuc" json:"ngay_ket_thuc"`
+	TemplateID  *uint      `gorm:"column:template_id" json:"template_id"`
 
+	SettingsJSON string `gorm:"column:settings_json;type:text" json:"-"`
+	ThemeJSON    string `gorm:"column:theme_json;type:text" json:"-"`
+	
 	// Quan hệ
 	CauHois  []CauHoi  `gorm:"foreignKey:KhaoSatID" json:"-"`
 	PhanHois []PhanHoi `gorm:"foreignKey:KhaoSatID" json:"-"`

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -34,5 +34,32 @@ func SetupRoutes(r *gin.Engine) {
 				c.JSON(200, gin.H{"ok": true})
 			})
 		}
+		forms := api.Group("/forms")
+		forms.Use(middleware.AuthJWT())
+		{
+			// BE-01..04
+			forms.POST("", controllers.CreateForm)
+			forms.GET("/:id", controllers.GetFormDetail)
+			forms.PUT("/:id", middleware.CheckFormOwner(), controllers.UpdateForm)
+			forms.DELETE("/:id", middleware.CheckFormOwner(), controllers.DeleteForm)
+
+			// (tuỳ chọn) Archive/Restore
+			forms.PUT("/:id/archive", middleware.CheckFormOwner(), controllers.ArchiveForm)
+			forms.PUT("/:id/restore", middleware.CheckFormOwner(), controllers.RestoreForm)
+
+			// BE-05: thêm câu hỏi
+			forms.POST("/:id/questions", middleware.CheckFormOwner(), controllers.AddQuestion)
+
+			// BE-08: reorder
+			forms.PUT("/:id/questions/reorder", middleware.CheckFormOwner(), controllers.ReorderQuestions)
+
+			// BE-09..10: settings
+			forms.PUT("/:id/settings", middleware.CheckFormOwner(), controllers.UpdateFormSettings)
+			forms.GET("/:id/settings", controllers.GetFormSettings)
+		}
+
+		api.PUT("/questions/:id", middleware.AuthJWT(), controllers.UpdateQuestion)    // BE-06
+    	api.DELETE("/questions/:id", middleware.AuthJWT(), controllers.DeleteQuestion) // BE-07
+
 	}
 }


### PR DESCRIPTION
# 📌 Tóm tắt
Hoàn thiện **Form Management APIs (BE-01 → BE-10)**: CRUD form, câu hỏi, sắp xếp và cài đặt.  
PR này hoàn tất lõi backend hệ thống khảo sát, sẵn sàng cho phía Frontend tích hợp.

---

# 🔑 Thay đổi chính

## 1) Models
- **KhaoSat**
  - Thêm `TemplateID *uint`
  - Thêm `SettingsJSON string` và `ThemeJSON string` (lưu JSON dạng TEXT)
- **CauHoi**
  - Thêm `PropsJSON string` (lưu thuộc tính động theo type: options/required/maxLen…)
- Cập nhật quan hệ (preload câu hỏi → preload lựa chọn), sắp xếp theo `thu_tu`.

## 2) Middleware
- `CheckFormOwner`: xác thực quyền chủ sở hữu form trước khi cập nhật/xoá/thay đổi thứ tự.
- Context keys: `CtxUser`, `formObj` (đưa user và form vào context để controller dùng).

## 3) Controllers
- **Forms**
  - BE-01: `POST /api/forms`
  - BE-02: `GET /api/forms/:id`
  - BE-03: `PUT /api/forms/:id`
  - BE-04: `DELETE /api/forms/:id`, `PUT /api/forms/:id/archive`, `PUT /api/forms/:id/restore`
  - BE-08: `PUT /api/forms/:id/questions/reorder`
- **Questions**
  - BE-05: `POST /api/forms/:id/questions`
  - BE-06: `PUT /api/questions/:id`
  - BE-07: `DELETE /api/questions/:id`
- **Settings**
  - BE-09: `PUT /api/forms/:id/settings`
  - BE-10: `GET /api/forms/:id/settings`

> Tất cả endpoint sửa/xoá yêu cầu **JWT + owner**.  
> Các truy vấn form loại trừ `trang_thai = 'deleted'`.

---

# 📂 Danh sách API cho FE

## Auth
- `POST /api/auth/google/login` → login bằng Google, trả JWT

## Forms
- `POST /api/forms` → tạo form  
- `GET /api/forms/:id` → chi tiết form  
- `PUT /api/forms/:id` → cập nhật form  
- `DELETE /api/forms/:id` → xoá mềm  
- `PUT /api/forms/:id/archive` → lưu trữ  
- `PUT /api/forms/:id/restore` → khôi phục  

## Questions
- `POST /api/forms/:id/questions` → thêm câu hỏi  
- `PUT /api/questions/:id` → cập nhật câu hỏi  
- `DELETE /api/questions/:id` → xoá câu hỏi  

## Reorder
- `PUT /api/forms/:id/questions/reorder` → sắp xếp lại  

## Settings
- `PUT /api/forms/:id/settings` → cập nhật settings  
- `GET /api/forms/:id/settings` → lấy settings  

---

# 📜 Đặc tả chi tiết BE-01 → BE-10

### BE-01 — `POST /api/forms`
**Headers**: `Authorization: Bearer <jwt>`  
**Input**:
```json
{ "title": "string", "description": "string?", "template_id": 1, "settings": { ... }, "theme": { ... } }
```
**Output 201**:
```json
{ "id": 1, "title": "...", "description": "...", "owner_id": 1, "created_at": "..." }
```
**Lỗi**: `422, 500`

---

### BE-02 — `GET /api/forms/{id}`
**Output 200**:
```json
{ "id": 1, "title": "...", "description": "...", "settings": {...}|null, "theme": {...}|null, "questions": [] }
```
**Lỗi**: `404, 500`

---

### BE-03 — `PUT /api/forms/{id}`
**Input**:
```json
{ "title": "?", "description": "?", "settings": { ... } }
```
**Output**:
```json
{ "message": "updated" }
```
**Lỗi**: `403, 404, 422, 500`

---

### BE-04 — `DELETE /api/forms/{id}` (soft delete)
**Output**:
```json
{ "message": "deleted" }
```
**Lỗi**: `403, 404, 500`

#### `PUT /api/forms/{id}/archive`
**Output**:
```json
{ "message": "archived" }
```

#### `PUT /api/forms/{id}/restore`
**Output**:
```json
{ "message": "restored" }
```

> GET vẫn xem được form **archived**. Form **deleted** trả 404.

---

### BE-05 — `POST /api/forms/{id}/questions`
**Input**:
```json
{ "type": "MCQ|TEXT|FILEUPLOAD|...", "content": "string", "props": { ... } }
```
**Output 201**:
```json
{ "question_id": 1, "form_id": 1 }
```
**Lỗi**: `403, 404, 422, 500`

---

### BE-06 — `PUT /api/questions/{id}`
**Input**:
```json
{ "content": "?", "props": { ... } }
```
**Output**:
```json
{ "message": "updated" }
```
**Lỗi**: `403, 404, 422, 500`

---

### BE-07 — `DELETE /api/questions/{id}`
**Output**:
```json
{ "message": "deleted" }
```
**Ghi chú**: các câu sau dồn `thu_tu - 1`.

---

### BE-08 — `PUT /api/forms/{id}/questions/reorder`
**Input**:
```json
{ "order": [15, 10, 18] }
```
**Output**:
```json
{ "message": "updated" }
```
**Lỗi**: `400, 403, 404, 500`

---

### BE-09 — `PUT /api/forms/{id}/settings`
**Input**:
```json
{ "settings": { "max_responses": 200, "collect_email": true, "show_progress": true, "shuffle_questions": false } }
```
**Output**:
```json
{ "message": "updated" }
```

---

### BE-10 — `GET /api/forms/{id}/settings`
**Output**:
```json
{ "settings": { ... } }
```

---

# 📑 Payload mẫu

### Tạo form
```http
POST /api/forms
{
  "title": "Khảo sát khách hàng",
  "description": "Thu thập ý kiến hàng tháng",
  "settings": { "collect_email": true, "shuffle_questions": false },
  "theme": { "primary": "#4f46e5" },
  "template_id": 1
}
```

### Thêm câu hỏi
```http
POST /api/forms/1/questions
{
  "type": "MCQ",
  "content": "Bạn thường dùng tính năng nào?",
  "props": { "options": ["Tìm kiếm", "Thông báo", "Thống kê"], "required": true }
}
```

### Reorder
```http
PUT /api/forms/1/questions/reorder
{ "order": [15, 10, 18, 11] }
```

### Update settings
```http
PUT /api/forms/1/settings
{ "settings": { "max_responses": 200, "collect_email": true, "show_progress": true, "shuffle_questions": false } }
```

---

# ✅ Tiêu chí nghiệm thu
- Đáp ứng đầy đủ BE-01 → BE-10.  
- Chỉ **owner** được sửa/xoá/reorder.  
- Form **deleted** → không thể GET (404).  
- `settings`, `theme`, `props` kiểm tra JSON hợp lệ trước khi lưu.  
- Thứ tự câu hỏi luôn nhất quán sau thêm/xoá/reorder.  

---

# 🎯 Hướng dẫn tích hợp cho FE
- **Login**: lấy `id_token` từ Google → gọi `POST /api/auth/google/login` → nhận JWT → gắn `Authorization: Bearer <jwt>` cho mọi request.  
- **Render form**: gọi `GET /api/forms/:id` → hiển thị `questions[] + settings + theme`.  
- **Chỉnh sửa**: dùng các API update/insert/delete/reorder.  
- **Trạng thái**:
  - `archived`: vẫn GET được (FE có thể ẩn nếu muốn).  
  - `deleted`: BE trả 404.  

---

# 📌 Ghi chú bổ sung
- Cần bổ sung index DB để tối ưu:
  - `khao_sat(nguoi_tao_id)`, `khao_sat(trang_thai)`  
  - `cau_hoi(khao_sat_id)`, composite `(khao_sat_id, thu_tu)`  
