### PR TITLE
BE27, BE28 export

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ func ConnectDB() {
 		&models.Room{},
 		&models.RoomNguoiThamGia{},
 		&models.RoomInvite{},
+		&models.ExportJob{},
 	); err != nil {
 		log.Fatalf("Failed to migrate: %v", err)
 	}

--- a/controllers/export_controller.go
+++ b/controllers/export_controller.go
@@ -1,0 +1,169 @@
+package controllers
+
+import (
+    "encoding/csv"
+    "fmt"
+    "net/http"
+    "os"
+    "path"
+    "time"
+
+    "github.com/gin-gonic/gin"
+    "github.com/google/uuid"
+    "gorm.io/gorm"
+
+    "github.com/vnkhanh/survey-server/config"
+    "github.com/vnkhanh/survey-server/models"
+)
+
+type ExportRequest struct {
+    Format             string  `json:"format"`
+    RangeFrom          *string `json:"range_from,omitempty"`
+    RangeTo            *string `json:"range_to,omitempty"`
+    IncludeAttachments bool    `json:"include_attachments"`
+}
+
+// POST /api/forms/:id/export
+func CreateExport(c *gin.Context) {
+    id := c.Param("id")
+
+    var form models.KhaoSat
+    if err := config.DB.First(&form, id).Error; err != nil {
+        if err == gorm.ErrRecordNotFound {
+            c.JSON(http.StatusNotFound, gin.H{"message": "Form không tồn tại"})
+            return
+        }
+        c.JSON(http.StatusInternalServerError, gin.H{"message": "Lỗi DB"})
+        return
+    }
+
+    var req ExportRequest
+    if err := c.ShouldBindJSON(&req); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"message": "Payload không hợp lệ"})
+        return
+    }
+    if req.Format == "" {
+        req.Format = "csv"
+    }
+
+    var fromPtr, toPtr *time.Time
+    if req.RangeFrom != nil {
+        if t, err := time.Parse(time.RFC3339, *req.RangeFrom); err == nil {
+            fromPtr = &t
+        }
+    }
+    if req.RangeTo != nil {
+        if t, err := time.Parse(time.RFC3339, *req.RangeTo); err == nil {
+            toPtr = &t
+        }
+    }
+
+    jobID := uuid.New().String()
+    job := models.ExportJob{
+        JobID:              jobID,
+        KhaoSatID:          form.ID,
+        Format:             req.Format,
+        RangeFrom:          fromPtr,
+        RangeTo:            toPtr,
+        IncludeAttachments: req.IncludeAttachments,
+        Status:             "queued",
+    }
+    config.DB.Create(&job)
+
+    go processExportJob(jobID)
+
+    c.JSON(http.StatusAccepted, gin.H{
+        "job_id": jobID,
+        "status": "queued",
+    })
+}
+
+// GET /api/exports/:job_id
+func GetExport(c *gin.Context) {
+    jobID := c.Param("job_id")
+    var job models.ExportJob
+    if err := config.DB.First(&job, "job_id = ?", jobID).Error; err != nil {
+        if err == gorm.ErrRecordNotFound {
+            c.JSON(http.StatusNotFound, gin.H{"message": "Job không tìm thấy"})
+            return
+        }
+        c.JSON(http.StatusInternalServerError, gin.H{"message": "Lỗi DB"})
+        return
+    }
+
+    if job.Status == "done" && job.FilePath != nil {
+        c.FileAttachment(*job.FilePath, path.Base(*job.FilePath))
+        return
+    }
+
+    c.JSON(http.StatusOK, gin.H{
+        "job_id": job.JobID,
+        "status": job.Status,
+        "error":  job.ErrorMsg,
+    })
+}
+
+// xử lý job xuất dữ liệu
+func processExportJob(jobID string) {
+    var job models.ExportJob
+    if err := config.DB.First(&job, "job_id = ?", jobID).Error; err != nil {
+        return
+    }
+    config.DB.Model(&job).Update("status", "processing")
+
+    outDir := "./exports"
+    os.MkdirAll(outDir, 0755)
+
+    filename := fmt.Sprintf("export_%s.csv", job.JobID)
+    outPath := path.Join(outDir, filename)
+
+    f, err := os.Create(outPath)
+    if err != nil {
+        em := err.Error()
+        config.DB.Model(&job).Updates(map[string]interface{}{"status": "failed", "error_msg": em})
+        return
+    }
+    defer f.Close()
+
+    w := csv.NewWriter(f)
+    defer w.Flush()
+
+    header := []string{"response_id", "email", "ngay_gui", "lan_gui", "answers"}
+    w.Write(header)
+
+    var responses []models.PhanHoi
+    q := config.DB.Preload("CauTraLois").Where("khao_sat_id = ?", job.KhaoSatID)
+    if job.RangeFrom != nil {
+        q = q.Where("ngay_gui >= ?", job.RangeFrom)
+    }
+    if job.RangeTo != nil {
+        q = q.Where("ngay_gui <= ?", job.RangeTo)
+    }
+    if err := q.Find(&responses).Error; err != nil {
+        em := err.Error()
+        config.DB.Model(&job).Updates(map[string]interface{}{"status": "failed", "error_msg": em})
+        return
+    }
+
+    for _, r := range responses {
+        email := ""
+        if r.Email != nil {
+            email = *r.Email
+        }
+        answers := ""
+        for _, a := range r.CauTraLois {
+            answers += fmt.Sprintf("[%d:%s] ", a.CauHoiID, a.NoiDung)
+        }
+        row := []string{
+            fmt.Sprintf("%d", r.ID),
+            email,
+            r.NgayGui.Format(time.RFC3339),
+            fmt.Sprintf("%d", r.LanGui),
+            answers,
+        }
+        w.Write(row)
+    }
+
+    fp := outPath
+    config.DB.Model(&job).Updates(map[string]interface{}{"status": "done", "file_path": fp})
+}

--- a/models/export_job.go
+++ b/models/export_job.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+type ExportJob struct {
+    JobID              string     `gorm:"column:job_id;primaryKey;size:36" json:"job_id"`
+    KhaoSatID          uint       `gorm:"column:khao_sat_id;index" json:"khao_sat_id"`
+    Format             string     `gorm:"column:format;size:10" json:"format"` // csv, xlsx
+    RangeFrom          *time.Time `gorm:"column:range_from" json:"range_from,omitempty"`
+    RangeTo            *time.Time `gorm:"column:range_to" json:"range_to,omitempty"`
+    IncludeAttachments bool       `gorm:"column:include_attachments" json:"include_attachments"`
+    Status             string     `gorm:"column:status;size:20;default:'queued'" json:"status"`
+    FilePath           *string    `gorm:"column:file_path;type:text" json:"file_path,omitempty"`
+    ErrorMsg           *string    `gorm:"column:error_msg;type:text" json:"error_msg,omitempty"`
+    CreatedAt          time.Time  `gorm:"autoCreateTime" json:"created_at"`
+    UpdatedAt          time.Time  `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+func (ExportJob) TableName() string {
+    return "export_jobs"
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -63,8 +63,10 @@ func SetupRoutes(r *gin.Engine) {
 			forms.GET("/:id/submissions", controllers.GetSubmissions) //BE-25
 			forms.GET("/:id/submissions/:sub_id", controllers.GetSubmissionDetail)
 			forms.GET("/:id/dashboard", controllers.GetFormDashboard)
+			forms.POST("/:id/export", middleware.CheckFormEditor(), controllers.CreateExport)
 		}
 		api.POST("/uploads", controllers.UploadFile)
+		api.GET("/exports/:job_id", middleware.AuthJWT(), controllers.GetExport)
 
 		api.PUT("/questions/:id", middleware.CheckQuestionEditor(), controllers.UpdateQuestion)    // BE-06
 		api.DELETE("/questions/:id", middleware.CheckQuestionEditor(), controllers.DeleteQuestion) // BE-07


### PR DESCRIPTION
# BE-27: Export Job

## Endpoint
`POST /api/forms/{id}/export`

## Chức năng
Cho phép owner/editor của form tạo job export dữ liệu khảo sát.

## Tính năng
- Hỗ trợ export với các tùy chọn:
  - **format** (CSV/XLSX)
  - **range_from** (thời gian bắt đầu)
  - **range_to** (thời gian kết thúc)
  - **include_attachments** (bao gồm file đính kèm)

## Luồng xử lý
- Khi gọi API, server push job vào hàng đợi
- Trả về `job_id` + `status` ngay lập tức

## Middleware
`CheckFormEditor()` → chỉ chủ form hoặc editor mới có quyền export.

---

# BE-28: Get Export Result

## Endpoint
`GET /api/exports/{job_id}`

## Chức năng
Kiểm tra trạng thái job export và tải file kết quả.

## Luồng xử lý
- **Nếu job đang chạy** → trả về `{status: "processing"}`
- **Nếu job hoàn tất** → trả file export (CSV/Excel) cho client tải về

## Middleware
`AuthJWT()` → chỉ user đăng nhập mới được phép tải file.

---

# Kết quả test

## 1. Tạo job export
- ✅ Trả về `job_id` thành công

## 2. Lấy kết quả export bằng job_id
- ✅ **Nếu chưa xong** → `status: processing`
- ✅ **Nếu xong** → tải file thành công

## Định dạng file CSV
Các cột trong file export:
- `response_id`
- `email` 
- `ngay_gui`
- `lan_gui`
- `answers`